### PR TITLE
Feat: Add functionality to edit passcode

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
-language: java
-jdk: oraclejdk7
+language: android
+jdk: oraclejdk8
 sudo: required
 android:
   components:

--- a/mifos-passcode/build.gradle
+++ b/mifos-passcode/build.gradle
@@ -63,9 +63,10 @@ tasks.withType(Javadoc) {
 }
 
 // Place it at the end of the file
-apply from: 'https://raw.githubusercontent.com/nuuneoi/JCenter/master/installv1.gradle'
-apply from: 'https://raw.githubusercontent.com/nuuneoi/JCenter/master/bintrayv1.gradle'
-
+if (project.rootProject.file('local.properties').exists()) {
+    apply from: 'https://raw.githubusercontent.com/nuuneoi/JCenter/master/installv1.gradle'
+    apply from: 'https://raw.githubusercontent.com/nuuneoi/JCenter/master/bintrayv1.gradle'
+}
 // Used this article to release the library
 // https://inthecheesefactory.com/blog/how-to-upload-library-to-jcenter-maven-central-as-dependency/en
 

--- a/mifos-passcode/src/main/java/com/mifos/mobile/passcode/MifosPassCodeActivity.java
+++ b/mifos-passcode/src/main/java/com/mifos/mobile/passcode/MifosPassCodeActivity.java
@@ -37,6 +37,7 @@ public abstract class MifosPassCodeActivity extends AppCompatActivity implements
     private boolean isPassCodeVerified;
     private String strPassCodeEntered;
     private PasscodePreferencesHelper passcodePreferencesHelper;
+    private boolean resetPasscode;
 
     public abstract int getLogo();
 
@@ -69,6 +70,7 @@ public abstract class MifosPassCodeActivity extends AppCompatActivity implements
 
         isInitialScreen = getIntent().getBooleanExtra(PassCodeConstants.PASSCODE_INITIAL_LOGIN,
                 false);
+        resetPasscode = getIntent().getBooleanExtra(PassCodeConstants.RESET_PASSCODE, false);
         isPassCodeVerified = false;
         strPassCodeEntered = "";
 
@@ -81,6 +83,12 @@ public abstract class MifosPassCodeActivity extends AppCompatActivity implements
             mifosPassCodeView.setPassCodeListener(this);
         }
 
+        if (resetPasscode) {
+            btnSkip.setVisibility(View.GONE);
+            btnSave.setVisibility(View.GONE);
+            tvPasscodeIntro.setVisibility(View.VISIBLE);
+            tvPasscodeIntro.setText(R.string.confirm_passcode);
+        }
     }
 
     private String encryptPassCode(String passCode) {
@@ -162,6 +170,10 @@ public abstract class MifosPassCodeActivity extends AppCompatActivity implements
         if (isPassCodeLengthCorrect()) {
             String passwordEntered = encryptPassCode(mifosPassCodeView.getPasscode());
             if (passcodePreferencesHelper.getPassCode().equals(passwordEntered)) {
+                if (resetPasscode) {
+                    resetPasscode();
+                    return;
+                }
                 startHomeActivity();
             } else {
                 mifosPassCodeView.startAnimation(shakeAnimation);
@@ -285,5 +297,16 @@ public abstract class MifosPassCodeActivity extends AppCompatActivity implements
         if (isInitialScreen) {
             super.onBackPressed();
         }
+    }
+
+    private void resetPasscode() {
+        resetPasscode = false;
+        btnSkip.setVisibility(View.VISIBLE);
+        btnSave.setVisibility(View.VISIBLE);
+        tvPasscodeIntro.setText(R.string.passcode_setup);
+        counter = 0;
+        mifosPassCodeView.clearPasscodeField();
+        mifosPassCodeView.setPassCodeListener(null);
+        passcodePreferencesHelper.clear();
     }
 }

--- a/mifos-passcode/src/main/java/com/mifos/mobile/passcode/utils/PassCodeConstants.java
+++ b/mifos-passcode/src/main/java/com/mifos/mobile/passcode/utils/PassCodeConstants.java
@@ -7,4 +7,5 @@ package com.mifos.mobile.passcode.utils;
 
 public class PassCodeConstants {
     public static final String PASSCODE_INITIAL_LOGIN = "initial_login";
+    public static final String RESET_PASSCODE = "reset_passcode";
 }

--- a/mifos-passcode/src/main/res/values/strings.xml
+++ b/mifos-passcode/src/main/res/values/strings.xml
@@ -12,6 +12,7 @@
     <string name="passcode_does_not_match">Passcode does not match.</string>
     <string name="forgot_passcode">Forgot passcode, login manually</string>
     <string name="no_internet_connection">No Internet Connection</string>
+    <string name="confirm_passcode">Confirm your passcode</string>
 
     <string name="one">1</string>
     <string name="two">2</string>


### PR DESCRIPTION
Fixes #17.

Adds functionality to reset passcode. The user first has to confirm his/her old passcode and then enter the new passcode twice. To reset the passcode just start the activity with the following intent:

`intent.setExtra(PassCodeConstants.RESET_PASSCODE, true)`